### PR TITLE
Hooks hierarchy fixes and no more added_to_section methods

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.11.2
+current_version = 1.12.0
 commit = true
 tag = false
 

--- a/configmanager/__init__.py
+++ b/configmanager/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.11.2'
+__version__ = '1.12.0'
 
 from .managers import Config
 from .items import Item

--- a/configmanager/base.py
+++ b/configmanager/base.py
@@ -5,9 +5,6 @@ class BaseItem(object):
     is_item = True
     is_section = False
 
-    def added_to_section(self, alias, section):
-        pass
-
 
 def is_config_item(obj):
     return isinstance(obj, BaseItem)
@@ -38,9 +35,6 @@ class BaseSection(object):
 
     def add_section(self, alias, section):
         raise NotImplementedError()
-
-    def added_to_section(self, alias, section):
-        pass
 
 
 def is_config_instance(obj):

--- a/configmanager/hooks.py
+++ b/configmanager/hooks.py
@@ -4,12 +4,14 @@ import collections
 class Hooks(object):
 
     NOT_FOUND = 'not_found'
-    ADDED_TO_SECTION = 'added_to_section'
+    ITEM_ADDED_TO_SECTION = 'item_added_to_section'
+    SECTION_ADDED_TO_SECTION = 'section_added_to_section'
     VALUE_CHANGED = 'value_changed'
 
     _names = (
         NOT_FOUND,
-        ADDED_TO_SECTION,
+        ITEM_ADDED_TO_SECTION,
+        SECTION_ADDED_TO_SECTION,
         VALUE_CHANGED,
     )
 
@@ -40,3 +42,7 @@ class Hooks(object):
             result = handler(*args, **kwargs)
             if result is not None:
                 return result
+
+        # Must also call callbacks in parent section hook registry
+        if self._config.section and self._config.section.hooks != self:
+            return self._config.section.hooks.handle(hook_name, *args, **kwargs)

--- a/configmanager/items.py
+++ b/configmanager/items.py
@@ -212,10 +212,3 @@ class Item(BaseItem):
         it hasn't been added to a section yet.
         """
         return self._section
-
-    def added_to_section(self, alias, section):
-        """
-        Hook to be used when extending *configmanager*. This is called
-        when the item has been added to a section.
-        """
-        self._section = section

--- a/configmanager/managers.py
+++ b/configmanager/managers.py
@@ -4,7 +4,7 @@ import copy
 
 import six
 
-from .base import BaseSection, is_config_item, is_config_section, ConfigRootAttribute
+from .base import BaseSection, is_config_item, is_config_section
 from .exceptions import NotFound
 from .hooks import Hooks
 from .items import Item
@@ -105,8 +105,6 @@ class Config(BaseSection):
     cm__item_cls = Item
     cm__configparser_factory = configparser.ConfigParser
 
-    hooks = ConfigRootAttribute('hooks', factory=Hooks)
-
     def __new__(cls, config_declaration=None, item_cls=None, configparser_factory=None):
         if config_declaration and isinstance(config_declaration, cls):
             return copy.deepcopy(config_declaration)
@@ -119,7 +117,8 @@ class Config(BaseSection):
         instance._cm__json_adapter = None
         instance._cm__yaml_adapter = None
         instance._cm__click_extension = None
-        instance._cm__hooks_extension = None
+
+        instance.__dict__['hooks'] = Hooks(config=instance)
 
         if item_cls:
             instance.cm__item_cls = item_cls
@@ -490,18 +489,6 @@ class Config(BaseSection):
         """
         return self._cm__section_alias
 
-    def added_to_section(self, alias, section):
-        """
-        A hook that is called when this section is added to another.
-        This should only be called when extending functionality of :class:`.Config`.
-        
-        Args:
-            alias (str): alias with which the section as added as a sub-section to another 
-            section (:class:`.Config`): section to which this section has been added
-        """
-        self._cm__section = section
-        self._cm__section_alias = alias
-
     @property
     def configparser(self):
         """
@@ -570,7 +557,10 @@ class Config(BaseSection):
             item.name = alias
         self._cm__configs[item.name] = item
         self._cm__configs[alias] = item
-        item.added_to_section(alias, self)
+
+        item._section = self
+
+        self.hooks.handle(Hooks.ITEM_ADDED_TO_SECTION, alias=alias, section=self, subject=item)
 
     def add_section(self, alias, section):
         """
@@ -579,4 +569,8 @@ class Config(BaseSection):
         if not isinstance(alias, six.string_types):
             raise TypeError('Section name must be a string, got a {!r}'.format(type(alias)))
         self._cm__configs[alias] = section
-        section.added_to_section(alias, self)
+
+        section._cm__section = self
+        section._cm__section_alias = alias
+
+        self.hooks.handle(Hooks.SECTION_ADDED_TO_SECTION, alias=alias, section=self, subject=section)

--- a/docs/api.rst.inc
+++ b/docs/api.rst.inc
@@ -16,7 +16,6 @@ Public Interface
       reset,
       is_default,
       section, alias,
-      added_to_section,
       configparser, json, yaml
 
 

--- a/docs/hooks.rst.inc
+++ b/docs/hooks.rst.inc
@@ -10,11 +10,15 @@ To hook into *configmanager*, you just have to write a function and register it 
 event by decorating it. Following hook events are defined:
 
 - ``not_found`` -- when a name is not found in a section
-- ``added_to_section`` -- *in development*
+- ``item_added_to_section`` -- when an item is added to a section
+- ``section_added_to_section`` -- when a section is added to a section
 - ``value_changed`` -- *in development*
 
-Callback functions should accept ``**kwargs`` and should return ``None`` unless they want to cancel
-other callback functions.
+You can register hooks on any section (instance of :class:`.Config`) and they will apply to all sub-sections.
+
+Callback functions should accept ``**kwargs`` and should return ``None``.
+If a callback returns non-``None`` result, subsequent callback execution will be
+cancelled. This also means that callbacks registered on parent section hooks will not be called.
 
 .. code-block:: python
 
@@ -32,27 +36,16 @@ other callback functions.
 
 ``not_found`` is the bit where you specify which hook you are registering the callback with.
 
-You can register hooks on instances of :class:`.Config` and they will apply to all sub-sections unless a
-sub-section has its own hooks registry. *This might change in future.*
 
-.. code-block:: python
-
-    >>> config.hooks is config.uploads.hooks
-    True
-
-    >>> config.hooks is config.uploads.db.hooks
-    True
-
-
-``<config>.hooks.not_found``
-----------------------------
+``Config.hooks.not_found``
+--------------------------
 
 ``not_found`` callbacks are called when user requests a non-existent item or section.
 
 Due to *configmanager*'s design it is impossible to tell whether user is requesting a section or an item.
 As a convention, it is fair to assume that user was requesting an item rather than a section.
 
-Callback is passed two **kwargs**:
+Callback is passed keyword arguments:
 
 - ``name=``, the name that was requested and was not found
 - ``section=``, the section in which the name was requested
@@ -87,3 +80,23 @@ This allows you to do the following now:
     >>> config.greeting.value = 'Good morning!'
     >>> config.greeting.get('Hello')
     'Good morning!
+
+
+``Config.hooks.item_added_to_section``
+--------------------------------------
+
+Callback is passed keyword arguments:
+
+- ``subject`` - item which was added
+- ``section`` - section to which the ``subject`` item was added
+- ``alias`` - name under which the ``subject`` item was added
+
+
+``Config.hooks.section_added_to_section``
+-----------------------------------------
+
+Callback is passed keyword arguments:
+
+- ``subject`` - subject which was added
+- ``section`` - parent section to which the ``subject`` section was added
+- ``alias`` - name under which the ``subject`` section was added


### PR DESCRIPTION
* Adds section_added_to_section hook
* Adds item_added_to_section hook
* Config.hooks is no longer ConfigRootAttribute as we need a separate instance on each level for consistency
* Section hook handler calls parent section hook handlers too
* Removes method Item.added_to_section — use hooks instead
* Removes method Config.added_to_section — use hooks instead