### PR TITLE
Track changes fixes and reset_changes() added

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.28.0
+current_version = 1.29.0
 commit = true
 tag = false
 

--- a/configmanager/__init__.py
+++ b/configmanager/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.28.0'
+__version__ = '1.29.0'
 
 from .managers import Config
 from .items import Item

--- a/configmanager/sections.py
+++ b/configmanager/sections.py
@@ -255,6 +255,10 @@ class Section(BaseSection):
 
     @property
     def hooks(self):
+        """
+        Returns:
+            HookRegistry
+        """
         return self._hooks
 
     @property

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -325,3 +325,17 @@ to be called when this exception is raised:
 
 
 If this function returns anything other than ``None``, the exception will not be raised.
+
+How can I track changes of config values?
+-----------------------------------------
+
+.. code-block:: python
+
+    >>> with config.tracking_context() as ctx:
+    ...     config.greeting.value = 'Hey, what is up!'
+
+    >>> len(ctx.changes)
+    1
+
+    >>> ctx.changes[config.greeting]
+    'Hey, what is up!'

--- a/tests/test_track_changes.py
+++ b/tests/test_track_changes.py
@@ -1,4 +1,5 @@
 from configmanager import Config
+from configmanager.utils import not_set
 
 
 def test_tracking_context():
@@ -67,3 +68,167 @@ def test_tracking_context():
 
     assert ctx1.changes == {config.db.user: 'user-in-ctx1', config.greeting: 'greeting-in-ctx1'}
     assert ctx2.changes == {config.greeting: 'greeting-in-ctx2'}
+
+
+def test_reset_changes_resets_changes_in_context_and_on_items():
+    config = Config({
+        'a': 'A1',
+        'b': 'B1',
+        'c': 'C1',
+        'd': 'D1',
+    })
+
+    with config.tracking_context() as ctx1:
+        config.a.value = 'A2'
+        config.c.value = 'C2'
+
+        assert config.a.value == 'A2'
+        assert config.c.value == 'C2'
+
+        assert ctx1.changes == {
+            config.a: 'A2',
+            config.c: 'C2',
+        }
+
+        ctx1.reset_changes()
+
+        assert ctx1.changes == {}
+
+    assert config.a.value == 'A1'
+    assert config.b.value == 'B1'
+    assert config.c.value == 'C1'
+    assert config.d.value == 'D1'
+
+    config.a.value = 'A3'
+    config.b.value = 'B3'
+    config.c.value = 'C3'
+
+    with config.tracking_context() as ctx2:
+        ctx2.reset_changes()
+
+        assert len(ctx2.changes) == 0
+
+        assert config.a.value == 'A3'
+        assert config.b.value == 'B3'
+        assert config.c.value == 'C3'
+        assert config.d.value == 'D1'
+
+        config.a.value = 'A4'
+        config.b.value = 'B4'
+
+        assert len(ctx2.changes) == 2
+
+        assert config.a.value == 'A4'
+        assert config.b.value == 'B4'
+        assert config.c.value == 'C3'
+        assert config.d.value == 'D1'
+
+        # Reset single
+        ctx2.reset_changes(config.b)
+        assert len(ctx2.changes) == 1
+        assert config.a.value == 'A4'
+        assert config.b.value == 'B3'
+
+        # Reset all
+        ctx2.reset_changes()
+        assert len(ctx2.changes) == 0
+
+    assert config.a.value == 'A3'
+    assert config.b.value == 'B3'
+    assert config.c.value == 'C3'
+    assert config.d.value == 'D1'
+
+
+def test_tracking_of_tricky_change_and_no_change_situations():
+    config = Config({'a': 'aaa'})
+
+    # Set custom value that matches the default. Should be tracked.
+    with config.tracking_context() as ctx:
+        assert len(ctx.changes) == 0
+
+        config.a.value = 'aaa'
+        assert len(ctx.changes) == 1
+
+        config.reset()
+        assert len(ctx.changes) == 0
+
+    # No custom value set to start with
+    with config.tracking_context() as ctx:
+        assert len(ctx.changes) == 0
+
+        # Set custom value
+        config.a.value = 'bbb'
+        assert len(ctx.changes) == 1
+        assert ctx.changes[config.a] == 'bbb'
+
+        # Set custom value which matches default value -- it still is a change.
+        config.a.value = 'aaa'
+        assert len(ctx.changes) == 1
+        assert ctx.changes[config.a] == 'aaa'
+
+        config.reset()
+        assert len(ctx.changes) == 0
+
+    # Have a custom value to start with
+    config.a.value = 'ccc'
+    with config.tracking_context() as ctx:
+
+        # Make one change
+        config.a.value = 'ddd'
+        assert len(ctx.changes) == 1
+        assert ctx.changes[config.a] == 'ddd'
+
+        # Change back to the original value (within this context), should result in no changes
+        config.a.value = 'ccc'
+        assert len(ctx.changes) == 0
+
+        # Reset still results in a change within this context.
+        config.reset()
+        assert len(ctx.changes) == 1
+        assert ctx.changes[config.a] == not_set
+
+
+def test_tracking_with_no_default_and_no_custom_value():
+    config = Config({'a': {'@type': 'int'}})
+
+    with config.tracking_context() as ctx:
+        config.a.value = 55
+
+    assert ctx.changes[config.a] == 55
+    assert len(ctx.changes) == 1
+
+    ctx.reset_changes()
+    assert len(ctx.changes) == 0
+
+
+def test_item_reset_is_tracked():
+    config = Config({'a': 'aaa'})
+    config.a.value = 'bbb'
+
+    with config.tracking_context() as ctx:
+        config.a.value = 'ccc'
+        assert len(ctx.changes) == 1
+
+        config.reset()
+        assert len(ctx.changes) == 1
+
+    assert ctx.changes[config.a] is not_set
+
+
+def test_resets_single_item_changes():
+    config = Config({'a': 'aaa', 'b': 'bbb'})
+
+    with config.tracking_context() as ctx:
+
+        config.a.value = 'AAA'
+        config.b.value = 'BBB'
+
+        assert len(ctx.changes) == 2
+
+        ctx.reset_changes(config.a)
+
+        assert len(ctx.changes) == 1
+        assert ctx.changes[config.b] == 'BBB'
+
+        assert config.a.value == 'aaa'
+        assert config.b.value == 'BBB'


### PR DESCRIPTION
* Adds item_value_changed triggering to Item.reset()
* Adds _TrackingContext.reset_changes() with optional item argument to reset changes in current context