### PR TITLE
Fixes load_values in PlainConfig

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.34.0
+current_version = 1.34.1
 commit = true
 tag = false
 

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,12 @@
 configmanager
 =============
 
+**Update on 2018-10-20**: I no longer use this library. It tries to do too many things. It was written in
+Python 2.7 and made work with Python 3. With type hints, dataclasses, and many other cool features in Python 3.6+
+you can express the same things in a much nicer way than this.
+
+----
+
 .. image:: https://travis-ci.org/jbasko/configmanager.svg?branch=master
     :target: https://travis-ci.org/jbasko/configmanager
 

--- a/configmanager/__init__.py
+++ b/configmanager/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.34.0'
+__version__ = '1.34.1'
 
 from .managers import Config
 from .items import Item

--- a/configmanager/sections.py
+++ b/configmanager/sections.py
@@ -574,14 +574,17 @@ class Section(BaseSection):
                         self[name] = self.create_item(name, default=value)
                 else:
                     # Skip unknown names if not interpreting dictionary as defaults
-                    continue
-            elif is_config_item(self[name]):
+                    pass
+                continue
+
+            resolution = self._get_item_or_section(name, handle_not_found=False)
+            if is_config_item(resolution):
                 if as_defaults:
-                    self[name].default = value
+                    resolution.default = value
                 else:
-                    self[name].value = value
+                    resolution.value = value
             else:
-                self[name].load_values(value, as_defaults=as_defaults)
+                resolution.load_values(value, as_defaults=as_defaults)
 
     def create_item(self, *args, **kwargs):
         """

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,8 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'License :: OSI Approved :: MIT License',
     ],
 )

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -9,7 +9,7 @@ def yaml_path1(tmpdir):
     return tmpdir.join('path1.yml').strpath
 
 
-def test_config_written_to_and_read_from_yaml_file(yaml_path1, simple_config):
+def test_config_written_to_and_read_from_yaml_file(yaml_path1):
     config = Config({
         'uploads': {
             'enabled': True,

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -1,7 +1,7 @@
 import pytest
 import six
 
-from configmanager import Config
+from configmanager import Config, PlainConfig
 
 
 @pytest.fixture
@@ -9,7 +9,7 @@ def yaml_path1(tmpdir):
     return tmpdir.join('path1.yml').strpath
 
 
-def test_config_written_to_and_read_from_yaml_file(yaml_path1):
+def test_config_written_to_and_read_from_yaml_file(yaml_path1, simple_config):
     config = Config({
         'uploads': {
             'enabled': True,
@@ -29,6 +29,15 @@ def test_config_written_to_and_read_from_yaml_file(yaml_path1):
     config2 = Config()
     config2.yaml.load(yaml_path1, as_defaults=True)
     assert config2.dump_values() == original_values
+
+
+def test_plain_config_loaded_from_yaml_file(yaml_path1):
+    with open(yaml_path1, "w") as f:
+        f.write("name: bar\n")
+
+    config = PlainConfig(schema={"name": "foo"})
+    config.yaml.load(yaml_path1)
+    assert config["name"] == "bar"
 
 
 def test_config_written_to_and_read_from_yaml_string():

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py27,py35
+envlist = py{27,35,36,37}
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
* Fixes #165 - Fixes `load_values` for `PlainConfig` where accessing item with `__getitem__` returns value so lower level method needs to be used in lookup
* Tested with Python 3.6 and 3.7
* Warn users about the state of the library
